### PR TITLE
Bug 1133007 - (LayerScope) Prevent sending duplicate texture image

### DIFF
--- a/js/bufferview_renderer.js
+++ b/js/bufferview_renderer.js
@@ -488,6 +488,8 @@ LayerScope.TwoDViewImp = {
 
   _createTexSprites: function TWD_createTexSprites(frame, $panel) {
     for (let texNode of frame.textureNodes) {
+      if (!texNode)
+        continue;
       let imageData = LayerScope.LayerBufferRenderer._graph.findImage(texNode.texID);
 
       if (imageData === undefined) {
@@ -500,11 +502,11 @@ LayerScope.TwoDViewImp = {
       .addClass(texNode.layerRef.low.toString());
 
       // name + target + size.
-      let $title = $("<div>").addClass("sprite-title");
-      $sprite.append($title);
+      let $title = $("<div>").addClass("sprite-title")
+        .appendTo($sprite);
       $title.append($("<p>" + texNode.name + " &mdash; " +
-       GLEnumNames[texNode.target] + " &mdash; "
-       + imageData.width + "x" + imageData.height + "</p>"));
+        GLEnumNames[texNode.target] + " &mdash; "+ imageData.width +
+        "x" + imageData.height + "</p>"));
 
       // layer ID.
       let layerID = null;
@@ -526,6 +528,19 @@ LayerScope.TwoDViewImp = {
       $sprite.append($canvas);
       this._textures.push($canvas);
 
+      // Create decorations.
+      // Red rectangle - denote new content
+      if (texNode.newContent) {
+        let $canvas = $("<canvas>")
+          .addClass("decoration-canvas")
+          .attr('width', 20)
+          .attr('height', 20)
+          .appendTo($sprite);
+        let ctx = $canvas[0].getContext("2d");
+        ctx.fillStyle = 'red';
+        ctx.fillRect(0, 0, 10, 20);
+      }
+
       // Last step, append this new sprite.
       $panel.append($sprite);
     }
@@ -538,6 +553,8 @@ LayerScope.TwoDViewImp = {
     for (let i = 0; i < textures.length; i++) {
       let $canvas = textures[i];
       let tex = this._frame.textureNodes[i];
+      if (!tex)
+        continue;
       let imageData = LayerScope.LayerBufferRenderer._graph.findImage(tex.texID);
 
       $canvas
@@ -563,6 +580,7 @@ LayerScope.TwoDViewImp = {
       .attr('height', imageData.height)
       ;
     let ctx = $canvas[0].getContext("2d");
+
     ctx.putImageData(imageData, 0, 0);
 
     return $canvas;

--- a/js/common.js
+++ b/js/common.js
@@ -84,7 +84,7 @@ LayerScope.utils = {
 
 //  Don't append any functions to this object, since we will
 //  serialize/deserialize this object into JSON string.
-LayerScope.TextureNode = function(name, target, texID, layerRef, contextRef) {
+LayerScope.TextureNode = function(name, target, texID, layerRef, contextRef, newContent) {
   this.name = name;
   this.target = target;
 
@@ -93,6 +93,7 @@ LayerScope.TextureNode = function(name, target, texID, layerRef, contextRef) {
   this.layerRef = layerRef;
   this.contextRef = contextRef;
   this.texID = texID;
+  this.newContent = newContent;
 }
 
 LayerScope.ImageDataPool = function () {

--- a/layerview.html
+++ b/layerview.html
@@ -55,6 +55,7 @@
       }
 
       .buffer-sprite {
+        position: relative;
         background: LightGray;
         font-size: 12px;
         /*padding: 5px;*/
@@ -64,6 +65,13 @@
         display: inline-block;
         vertical-align: top;
         font-weight: bold;
+      }
+      .decoration-canvas {
+        position: absolute;
+        right: 0px;
+        top: 20px;
+        width: 20px;
+        height: 20px;
       }
 
       .sprite-title {


### PR DESCRIPTION
1. Create a singleton holder to hold all singltons in LayerScope
2. Send the content of a texture only if it was altered after last transmission.