### PR TITLE
Bug1195653 - Part2: Show mask effect on LayerScope viewer.

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -107,7 +107,7 @@ LayerScope.utils = {
 
 //  Don't append any functions to this object, since we will
 //  serialize/deserialize this object into JSON string.
-LayerScope.TextureNode = function(name, target, texID, layerRef, contextRef, newContent) {
+LayerScope.TextureNode = function(name, target, texID, layerRef, contextRef, newContent, isMask) {
   this.name = name;
   this.target = target;
 
@@ -117,6 +117,7 @@ LayerScope.TextureNode = function(name, target, texID, layerRef, contextRef, new
   this.contextRef = contextRef;
   this.texID = texID;
   this.newContent = newContent;
+  this.isMask = isMask;
 }
 
 LayerScope.ImageDataPool = function () {

--- a/js/dataprocesser_worker.js
+++ b/js/dataprocesser_worker.js
@@ -200,7 +200,8 @@ LayerWorker.TexBuilder = {
                                                 this._contentMap[i].key,
                                                 layerRef,
                                                 ptexture.glcontext,
-                                                false);
+                                                false,
+                                                ptexture.isMask);
           return node;
         }
       }
@@ -221,7 +222,8 @@ LayerWorker.TexBuilder = {
                                         key,
                                         layerRef,
                                         ptexture.glcontext,
-                                        true);
+                                        true,
+                                        ptexture.isMask);
 
     // Update content map.
     for (var i = 0; i < this._contentMap.length; i++) {

--- a/js/protobuf/LayerScopePacket.proto
+++ b/js/protobuf/LayerScopePacket.proto
@@ -20,6 +20,7 @@ message ColorPacket {
 }
 
 message TexturePacket {
+  // Basic info
   required uint64 layerref = 1;
   optional uint32 width = 2;
   optional uint32 height = 3;
@@ -29,6 +30,13 @@ message TexturePacket {
   optional uint32 dataformat = 7;
   optional uint64 glcontext = 8;
   optional bytes data = 9;
+
+  // Texture effect attributes (10 to 19)
+  // TODO: reserved for primary textured effect attributes, see Bug 1205521
+
+  // Mask effect attributes (20 to 29)
+  optional bool isMask = 20;
+  // TODO: reserved for secondary mask effect attributes, see Bug 1205521
 }
 
 message LayersPacket {

--- a/js/renderer/texturesprite_renderer.js
+++ b/js/renderer/texturesprite_renderer.js
@@ -90,6 +90,11 @@ LayerScope.SpriteView = {
         $title.append($("<p>Layer " + LayerScope.utils.hex8(layerID) + "</p>"));
       }
 
+      // show isMask.
+      if (texNode.isMask) {
+        $title.append($("<p>Mask</p>"));
+      }
+
       if (!!layerID){
         $sprite.on("click", function() {
           LayerScope.MessageCenter.fire("buffer.select",

--- a/js/renderer/texturesprite_renderer.js
+++ b/js/renderer/texturesprite_renderer.js
@@ -13,6 +13,7 @@ LayerScope.SpriteView = {
   _frame: null,
   _textures: [],
   _colors: [],
+  _sortedSprites: [],
 
   layerSelection: function SV_layerSelection(layerID) {
     $(".selected-sprite").removeClass("selected-sprite");
@@ -49,14 +50,34 @@ LayerScope.SpriteView = {
       this._$panel.empty();
       this._textures = [];
       this._colors = [];
+      this._sortedSprites = [];
 
       this._createTexSprites(frame, this._$panel);
       this._createColorSprites(frame, this._$panel);
+      this._sortedSprites.forEach(sprite => {
+        this._$panel.append(sprite);
+      });
+
       this._frame = frame;
     }
 
     // Fit texCanvas size according to the current zoom ratio.
     this._resizeSprites(this._textures, this._colors);
+  },
+
+  _sortSpriteByLayerID: function SV_sortSpriteByLayerID($sprite) {
+    var inserted = false;
+    for (i = 0; i < this._sortedSprites.length; i++) {
+      if ($sprite.layerID < this._sortedSprites[i].layerID) {
+        this._sortedSprites.splice(i, 0, $sprite);
+        inserted = true;
+        break;
+      }
+    }
+
+    if (!inserted) {
+      this._sortedSprites.push($sprite);
+    }
   },
 
   _createTexSprites: function SV_createTexSprites(frame, $panel) {
@@ -89,6 +110,7 @@ LayerScope.SpriteView = {
         $sprite.attr("data-layer-id", layerID.toString());
         $title.append($("<p>Layer " + LayerScope.utils.hex8(layerID) + "</p>"));
       }
+      $sprite.layerID = layerID;
 
       // show isMask.
       if (texNode.isMask) {
@@ -120,8 +142,8 @@ LayerScope.SpriteView = {
         ctx.fillRect(0, 0, 10, 20);
       }
 
-      // Last step, append this new sprite.
-      $panel.append($sprite);
+      // Last step, push this new sprite to sorted array.
+      this._sortSpriteByLayerID($sprite);
     }
   },
 
@@ -174,6 +196,7 @@ LayerScope.SpriteView = {
 
       let layerID = o.layerRef.low;
       $title.attr("data-layer-id", layerID.toString());
+      $sprite.layerID = layerID;
 
       if (o.type == "Color") {
         var $bgdiv = $("<div>").addClass("background-" + LayerScope.Config.background);
@@ -190,7 +213,8 @@ LayerScope.SpriteView = {
       });
 
       $sprite.append($bgdiv);
-      $panel.append($sprite);
+      // Last step, push this new sprite to sorted array.
+      this._sortSpriteByLayerID($sprite);
     }
   }
 };


### PR DESCRIPTION
Bug 1195653 - part2.1: Show isMask attribute on viewer title bar.
Bug 1195653 - Part2.2: Let sprites in texture view be displayed in order of layerID, so mask effect can be shown right next to its primary effect.